### PR TITLE
body param path

### DIFF
--- a/modules/router/src/annotations.ts
+++ b/modules/router/src/annotations.ts
@@ -72,8 +72,10 @@ export interface ParamAnnotation {
 }
 
 class BodyParamAnnotation implements ParamAnnotation {
+  constructor(private key?: string) {}
+
   extractValue(context: RouterContext<any>) {
-    return context.req.body
+    return this.key ? context.req.body && context.req.body[this.key] : context.req.body
   }
 }
 
@@ -101,7 +103,7 @@ class HeaderParamAnnotation implements ParamAnnotation {
   }
 }
 
-const Body = createAnnotationFactory(BodyParamAnnotation),
+const Body: (key?: string) => Annotation = createAnnotationFactory(BodyParamAnnotation),
   Path = createAnnotationFactory(PathParamAnnotation),
   Query = createAnnotationFactory(QueryParamAnnotation),
   Header = createAnnotationFactory(HeaderParamAnnotation),

--- a/modules/router/test/router.spec.ts
+++ b/modules/router/test/router.spec.ts
@@ -162,6 +162,11 @@ describe('Routing', () => {
         return data
       }
 
+      @Route.Post('body-key-lookup')
+      bodyParamKeyLookup(@Param.Body('key') data: any) {
+        return data
+      }
+
       @Route.Get('path-param-lookup/:id')
       pathParamLookup(@Param.Path('id') id: string) {
         return id
@@ -305,6 +310,18 @@ describe('Routing', () => {
     it('should look up a body param', () => {
       return postAsync('/api/param-lookup/body-lookup', 'content').then(res => {
         expect(res).to.eql('content')
+      })
+    })
+
+    it('should look up a body param by key', () => {
+      return postAsync('/api/param-lookup/body-key-lookup', { key: 'content' }).then(res => {
+        expect(res).to.eql('content')
+      })
+    })
+
+    it('should return undefined when looking up a key for a null body', () => {
+      return postAsync('/api/param-lookup/body-key-lookup', null).then(res => {
+        expect(res).to.eql('OK')
       })
     })
 


### PR DESCRIPTION
Allows body values to be looked up by key if possible.

`@Param.Body('myKey')`